### PR TITLE
Fix: Add missing alt tags to images for accessibility

### DIFF
--- a/force-app/main/default/lwc/hero/hero.html
+++ b/force-app/main/default/lwc/hero/hero.html
@@ -1,5 +1,5 @@
 <template>
-    <img alt="" lwc:if={isImg} src={resUrl} />
+    <img alt={title} lwc:if={isImg} src={resUrl} />
     <video lwc:if={isVideo} autoplay muted loop>
         <source src={resUrl} type="video/mp4" />
     </video>

--- a/force-app/main/default/lwc/productCard/productCard.html
+++ b/force-app/main/default/lwc/productCard/productCard.html
@@ -13,7 +13,7 @@
                     lwc:if={productPictureUrl}
                     src={productPictureUrl}
                     class="product"
-                    alt=""
+                    alt={productName}
                 />
                 <lightning-record-view-form
                     record-id={recordId}

--- a/force-app/main/default/lwc/productListItem/productListItem.html
+++ b/force-app/main/default/lwc/productListItem/productListItem.html
@@ -1,7 +1,7 @@
 <template>
     <lightning-layout vertical-align="center">
         <lightning-layout-item
-            ><img src={product.Picture_URL__c} class="product" alt=""
+            ><img src={product.Picture_URL__c} class="product" alt={product.Name}
         /></lightning-layout-item>
         <lightning-layout-item
             flexibility="grow"

--- a/force-app/main/default/lwc/productTile/productTile.html
+++ b/force-app/main/default/lwc/productTile/productTile.html
@@ -5,6 +5,7 @@
                 <img
                     src={pictureUrl}
                     class="product slds-align_absolute-center"
+                    alt={name}
                 />
                 <div>
                     <p class="title slds-align_absolute-center">{name}</p>


### PR DESCRIPTION
This pull request addresses an accessibility issue where images were missing alternative text, making the application less accessible to users with screen readers. 

I have made the following changes:
- **productCard.html:** Added an `alt` tag to the product image, using the product name as the alternative text.
- **productListItem.html:** Added an `alt` tag to the product image, using the product name as the alternative text.
- **productTile.html:** Added an `alt` tag to the product image, using the product name as the alternative text.
- **hero.html:** Added an `alt` tag to the hero image, using the hero title as the alternative text.

These changes ensure that all images now have descriptive alternative text, improving the user experience for visually impaired users.