### PR TITLE
Feat: Add missing alt tags to images

### DIFF
--- a/force-app/main/default/lwc/orderItemTile/orderItemTile.html
+++ b/force-app/main/default/lwc/orderItemTile/orderItemTile.html
@@ -3,7 +3,7 @@
         <img
             src={orderItem.Product__r.Picture_URL__c}
             class="product slds-align_absolute-center"
-            alt=""
+            alt={orderItem.Product__r.Name}
         />
         <p class="title slds-align_absolute-center">
             {orderItem.Product__r.Name}

--- a/force-app/main/default/lwc/productCard/productCard.html
+++ b/force-app/main/default/lwc/productCard/productCard.html
@@ -13,7 +13,7 @@
                     lwc:if={productPictureUrl}
                     src={productPictureUrl}
                     class="product"
-                    alt=""
+                    alt={productName}
                 />
                 <lightning-record-view-form
                     record-id={recordId}

--- a/force-app/main/default/lwc/productTile/productTile.html
+++ b/force-app/main/default/lwc/productTile/productTile.html
@@ -5,6 +5,7 @@
                 <img
                     src={pictureUrl}
                     class="product slds-align_absolute-center"
+                    alt={name}
                 />
                 <div>
                     <p class="title slds-align_absolute-center">{name}</p>


### PR DESCRIPTION
This pull request addresses an accessibility issue where images were missing alternative text. The following changes have been made:

- Added `alt` tags to images in the `productTile`, `productCard`, and `orderItemTile` components.
- The `alt` text is dynamically set to the product name, providing better context for screen readers and improving the user experience for visually impaired users.

This resolves the customer complaint regarding missing alt tags.