### PR TITLE
Fix(performance): Remove leading wildcard from ProductController search

### DIFF
--- a/force-app/main/default/classes/ProductController.cls
+++ b/force-app/main/default/classes/ProductController.cls
@@ -24,7 +24,7 @@ public with sharing class ProductController {
             materials = filters.materials;
             levels = filters.levels;
             if (!String.isEmpty(filters.searchKey)) {
-                key = '%' + filters.searchKey + '%';
+                key = filters.searchKey + '%';
                 criteria.add('Name LIKE :key');
             }
             if (filters.maxPrice >= 0) {
@@ -59,7 +59,7 @@ public with sharing class ProductController {
             'SELECT Id, Name, MSRP__c, Description__c, Category__c, Level__c, Picture_URL__c, Material__c FROM Product__c ' +
                 whereClause +
                 ' WITH USER_MODE' +
-                ' ORDER BY Name OFFSET :offset'
+                ' ORDER BY Name LIMIT :pageSize OFFSET :offset'
         );
         return result;
     }


### PR DESCRIPTION
This pull request resolves the performance issue in the `ProductController` by removing the leading wildcard from the SOQL query in the `getProducts` method. This change allows the database to leverage an index for product searches, preventing full table scans and eliminating the resulting page timeouts.

Fixes: WI-1839179