### PR TITLE
feat(product): WI-424242 implement keyset pagination

### DIFF
--- a/force-app/main/default/classes/PagedResult.cls
+++ b/force-app/main/default/classes/PagedResult.cls
@@ -1,13 +1,10 @@
 public with sharing class PagedResult {
     @AuraEnabled
     public Integer pageSize { get; set; }
-
     @AuraEnabled
-    public Integer pageNumber { get; set; }
-
+    public Boolean hasMore { get; set; }
     @AuraEnabled
-    public Integer totalItemCount { get; set; }
-
+    public String nextPageToken { get; set; }
     @AuraEnabled
     public Object[] records { get; set; }
 }

--- a/force-app/main/default/classes/ProductController.cls
+++ b/force-app/main/default/classes/ProductController.cls
@@ -15,7 +15,7 @@ public with sharing class ProductController {
     }
 
     @AuraEnabled(Cacheable=true scope='global')
-    public static PagedResult getProducts(Filters filters, Integer pageNumber) {
+    public static PagedResult getProducts(Filters filters, String pageToken) {
         String key, whereClause = '';
         Decimal maxPrice;
         String[] categories, materials, levels, criteria = new List<String>{};
@@ -43,24 +43,40 @@ public with sharing class ProductController {
                 materials = filters.materials;
                 criteria.add('Material__c IN :materials');
             }
-            if (criteria.size() > 0) {
-                whereClause = 'WHERE ' + String.join(criteria, ' AND ');
-            }
         }
+
+        if (String.isNotBlank(pageToken)) {
+            criteria.add('Name > :pageToken');
+        }
+
+        if (criteria.size() > 0) {
+            whereClause = 'WHERE ' + String.join(criteria, ' AND ');
+        }
+
         Integer pageSize = ProductController.PAGE_SIZE;
-        Integer offset = (pageNumber - 1) * pageSize;
+        Integer queryLimit = pageSize + 1;
+
         PagedResult result = new PagedResult();
         result.pageSize = pageSize;
-        result.pageNumber = pageNumber;
-        result.totalItemCount = Database.countQuery(
-            'SELECT count() FROM Product__c ' + whereClause
-        );
-        result.records = Database.query(
+
+        List<Product__c> products = Database.query(
             'SELECT Id, Name, MSRP__c, Description__c, Category__c, Level__c, Picture_URL__c, Material__c FROM Product__c ' +
                 whereClause +
                 ' WITH USER_MODE' +
-                ' ORDER BY Name OFFSET :offset'
+                ' ORDER BY Name' +
+                ' LIMIT :queryLimit'
         );
+
+        if (products.size() == queryLimit) {
+            result.hasMore = true;
+            products.remove(products.size() - 1);
+            result.nextPageToken = products[products.size() - 1].Name;
+        } else {
+            result.hasMore = false;
+            result.nextPageToken = null;
+        }
+
+        result.records = products;
         return result;
     }
 


### PR DESCRIPTION
**Title:** feat(product): WI-424242 implement keyset pagination

**Summary**

- This PR addresses performance degradation in the `ProductController.cls` Apex class by implementing keyset pagination.

**Related Issue(s)**

- Resolves WI-424242

**Changes**

- Replaced offset-based pagination with keyset pagination in `ProductController.cls` to improve performance and avoid timeouts.
- Removed the expensive `Database.countQuery` which was causing full table scans.
- Updated the `PagedResult.cls` class to support the new pagination model, providing a `nextPageToken` and a `hasMore` flag for the front-end.

**Additional Notes**

- It is recommended to index the frequently filtered fields (`Category__c`, `Level__c`, `Material__c`) in Salesforce to further improve query performance.
- The search functionality still uses a leading wildcard, which can be slow. Consider updating the UI to avoid leading wildcards in search terms if possible.