### PR TITLE
feat: add missing alt tags to images

### DIFF
--- a/force-app/main/default/lwc/hero/hero.html
+++ b/force-app/main/default/lwc/hero/hero.html
@@ -1,5 +1,5 @@
 <template>
-    <img alt="" lwc:if={isImg} src={resUrl} />
+    <img alt={alternativeText} lwc:if={isImg} src={resUrl} />
     <video lwc:if={isVideo} autoplay muted loop>
         <source src={resUrl} type="video/mp4" />
     </video>

--- a/force-app/main/default/lwc/orderItemTile/orderItemTile.html
+++ b/force-app/main/default/lwc/orderItemTile/orderItemTile.html
@@ -3,7 +3,7 @@
         <img
             src={orderItem.Product__r.Picture_URL__c}
             class="product slds-align_absolute-center"
-            alt=""
+            alt={orderItem.Product__r.Name}
         />
         <p class="title slds-align_absolute-center">
             {orderItem.Product__r.Name}

--- a/force-app/main/default/lwc/placeholder/placeholder.html
+++ b/force-app/main/default/lwc/placeholder/placeholder.html
@@ -1,6 +1,6 @@
 <template>
     <div class="slds-var-p-around_large">
-        <img src={logoUrl} class="logo" alt="" />
+        <img src={logoUrl} class="logo" alt="E-Bikes logo" />
         <p class="slds-var-p-around_small">{message}</p>
     </div>
 </template>

--- a/force-app/main/default/lwc/productCard/productCard.html
+++ b/force-app/main/default/lwc/productCard/productCard.html
@@ -13,7 +13,7 @@
                     lwc:if={productPictureUrl}
                     src={productPictureUrl}
                     class="product"
-                    alt=""
+                    alt={productName}
                 />
                 <lightning-record-view-form
                     record-id={recordId}

--- a/force-app/main/default/lwc/productListItem/productListItem.html
+++ b/force-app/main/default/lwc/productListItem/productListItem.html
@@ -1,7 +1,10 @@
 <template>
     <lightning-layout vertical-align="center">
         <lightning-layout-item
-            ><img src={product.Picture_URL__c} class="product" alt=""
+            ><img
+                src={product.Picture_URL__c}
+                class="product"
+                alt={product.Name}
         /></lightning-layout-item>
         <lightning-layout-item
             flexibility="grow"

--- a/force-app/main/default/lwc/productTile/productTile.html
+++ b/force-app/main/default/lwc/productTile/productTile.html
@@ -5,6 +5,7 @@
                 <img
                     src={pictureUrl}
                     class="product slds-align_absolute-center"
+                    alt={name}
                 />
                 <div>
                     <p class="title slds-align_absolute-center">{name}</p>


### PR DESCRIPTION
**Summary**

- This PR addresses an accessibility issue by adding missing `alt` tags to images in various Lightning Web Components. This ensures that screen readers can provide descriptive information about the images to visually impaired users.

**Related Issue(s)**

- Resolves WI-424242

**Changes**

- Added `alt` tags to images in the following components:
    -   `productTile`
    -   `productCard`
    -   `orderItemTile`
    -   `placeholder`
    -   `hero`
    -   `productListItem`

**Additional Notes**

- None