### PR TITLE
Fix(Performance): Resolve SOQL Performance Issue in ProductController

### DIFF
--- a/force-app/main/default/classes/ProductController.cls
+++ b/force-app/main/default/classes/ProductController.cls
@@ -24,7 +24,7 @@ public with sharing class ProductController {
             materials = filters.materials;
             levels = filters.levels;
             if (!String.isEmpty(filters.searchKey)) {
-                key = '%' + filters.searchKey + '%';
+                key = filters.searchKey + '%';
                 criteria.add('Name LIKE :key');
             }
             if (filters.maxPrice >= 0) {


### PR DESCRIPTION
**Summary**

This PR resolves a performance degradation issue in the `ProductController.cls` Apex class. The root cause was identified as a SOQL query using a leading wildcard in a `LIKE` clause, which prevented the use of indexes and led to slow query performance.

**Related Issue(s)**

- Resolves WI-6189141

**Changes**

- Modified `ProductController.cls` to remove the leading wildcard from the `LIKE` clause in the `getProducts` method. This change allows the query to leverage database indexes, significantly improving performance.